### PR TITLE
fix(auth): Use ZVPD in alignment with the frontend service

### DIFF
--- a/app/uk/gov/hmrc/vapingduty/models/requests/IdentifierRequest.scala
+++ b/app/uk/gov/hmrc/vapingduty/models/requests/IdentifierRequest.scala
@@ -18,4 +18,4 @@ package uk.gov.hmrc.vapingduty.models.requests
 
 import play.api.mvc.{Request, WrappedRequest}
 
-case class IdentifierRequest[A](request: Request[A], vppaId: String, userId: String) extends WrappedRequest[A](request)
+case class IdentifierRequest[A](request: Request[A], vpdId: String, userId: String) extends WrappedRequest[A](request)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -75,5 +75,5 @@ microservice {
 
 enrolment {
   serviceName = "HMRC-VPD-ORG"
-  identifierKey = "VPPAID"
+  identifierKey = "ZVPD"
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,8 +2,8 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "10.4.0"
-  private val hmrcMongoVersion = "2.10.0"
+  private val bootstrapVersion = "10.5.0"
+  private val hmrcMongoVersion = "2.12.0"
 
   val compile = Seq(
     "uk.gov.hmrc"             %% "bootstrap-backend-play-30"  % bootstrapVersion,

--- a/test/uk/gov/hmrc/vapingduty/controllers/actions/AuthorisedActionSpec.scala
+++ b/test/uk/gov/hmrc/vapingduty/controllers/actions/AuthorisedActionSpec.scala
@@ -48,11 +48,11 @@ class AuthorisedActionSpec extends AnyFreeSpec
   with ScalaFutures {
   
   val enrolment               = "HMRC-VPD-ORG"
-  val vppaIdKey               = "VPPAID"
-  val vppaId                  = "XMADP9876543210"
+  val vpdIdKey                = "ZVPD"
+  val vpdId                  = "XMADP9876543210"
   val internalId: String      = "internalId"
   val state                   = "Activated"
-  val enrolments              = Enrolments(Set(Enrolment(enrolment, Seq(EnrolmentIdentifier(vppaIdKey, vppaId)), state)))
+  val enrolments              = Enrolments(Set(Enrolment(enrolment, Seq(EnrolmentIdentifier(vpdIdKey, vpdId)), state)))
   val emptyEnrolments         = Enrolments(Set.empty)
   val enrolmentsWithoutAppaId = Enrolments(Set(Enrolment(enrolment, Seq.empty, state)))
   val testContent             = "Test"
@@ -117,7 +117,7 @@ class AuthorisedActionSpec extends AnyFreeSpec
       status(result) mustBe UNAUTHORIZED
     }
 
-    "execute the block and throw AuthorisationException if cannot get the VPPAID enrolment" in {
+    "execute the block and throw AuthorisationException if cannot get the ZVPD enrolment" in {
       when(
         mockAuthConnector.authorise(
           eqTo(

--- a/test/uk/gov/hmrc/vapingduty/controllers/actions/AuthorisedActionSpec.scala
+++ b/test/uk/gov/hmrc/vapingduty/controllers/actions/AuthorisedActionSpec.scala
@@ -49,7 +49,7 @@ class AuthorisedActionSpec extends AnyFreeSpec
   
   val enrolment               = "HMRC-VPD-ORG"
   val vpdIdKey                = "ZVPD"
-  val vpdId                  = "XMADP9876543210"
+  val vpdId                   = "XMADP9876543210"
   val internalId: String      = "internalId"
   val state                   = "Activated"
   val enrolments              = Enrolments(Set(Enrolment(enrolment, Seq(EnrolmentIdentifier(vpdIdKey, vpdId)), state)))

--- a/test/uk/gov/hmrc/vapingduty/controllers/actions/FakeAuthorisedAction.scala
+++ b/test/uk/gov/hmrc/vapingduty/controllers/actions/FakeAuthorisedAction.scala
@@ -28,7 +28,7 @@ class FakeAuthorisedAction @Inject()(bodyParsers: PlayBodyParsers) extends Autho
 
   override def invokeBlock[A](request: Request[A], block: IdentifierRequest[A] => Future[Result]): Future[Result] =
     block(
-      IdentifierRequest(request, "vppaId", "userId")
+      IdentifierRequest(request, "vpdId", "userId")
     )
 
   override protected def executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global


### PR DESCRIPTION
The frontend service home page at the moment errors on Staging because

- it is pinging the backend service but that is still configured to extract "VPPAID", which errors and then causes a "there is a problem with this page" message to pop up on our home page on staging.
